### PR TITLE
Try another tag name when looking for project files.

### DIFF
--- a/ST2Makefile.py
+++ b/ST2Makefile.py
@@ -86,6 +86,8 @@ except Exception, e:
     sys.stderr.write("Error: cannot parse TrueSTUDIO .project file: %s\r\n" % ts_project)
     sys.exit(T2M_ERR_PROJECT_FILE)
 nodes = root.findall('linkedResources/link[type=\'1\']/locationURI')
+if not nodes:
+    nodes = root.findall('linkedResources/link[type=\'1\']/location')
 sources = []
 for node in nodes:
     sources.append(replace_path(node.text))


### PR DESCRIPTION
Between STM32CubeMX versions 4.12.0 and 4.20.1 there has been a
change in generated .cproject file format: source file paths are
specified by "locationURI" tag in the older version and by
"location" in another. This helps locate source files in both
older and newer .cproject files.

Signed-off-by: Alexander Lukichev <alexander.lukichev@gmail.com>